### PR TITLE
Provide `with_header` method on client

### DIFF
--- a/src/insert.rs
+++ b/src/insert.rs
@@ -88,6 +88,10 @@ impl<T> Insert<T> {
 
         let mut builder = Request::post(url.as_str());
 
+        for (name, value) in &client.headers {
+            builder = builder.header(name, value);
+        }
+
         if let Some(user) = &client.user {
             builder = builder.header("X-ClickHouse-User", user);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub struct Client {
     password: Option<String>,
     compression: Compression,
     options: HashMap<String, String>,
+    headers: HashMap<String, String>,
 }
 
 impl Default for Client {
@@ -103,6 +104,7 @@ impl Client {
             password: None,
             compression: Compression::default(),
             options: HashMap::new(),
+            headers: HashMap::new(),
         }
     }
 
@@ -177,6 +179,18 @@ impl Client {
     /// ```
     pub fn with_option(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.options.insert(name.into(), value.into());
+        self
+    }
+
+    /// Used to specify a header that will be passed to all queries.
+    ///
+    /// # Example
+    /// ```
+    /// # use clickhouse::Client;
+    /// Client::default().with_header("Cookie", "A=1");
+    /// ```
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(name.into(), value.into());
         self
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -160,6 +160,10 @@ impl Query {
 
         let mut builder = Request::builder().method(method).uri(url.as_str());
 
+        for (name, value) in &self.client.headers {
+            builder = builder.header(name, value);
+        }
+
         if content_length == 0 {
             builder = builder.header(CONTENT_LENGTH, "0");
         } else {


### PR DESCRIPTION
This change allows arbitrary headers to be included in requests to ClickHouse.

It uses `HeaderName` and `HeaderValue` which is efficient for use with `hyper`. The types are provided by the `http` crate to allow support for other HTTP client crates to use these types without requiring the full `hyper` crate.

There are other ways to provide this capability, including unsealing the `HttpClient` trait to allow more implementations. However, this change provides a limited additional capability until a public interface for `HttpClient` is decided.

Fixes #98 